### PR TITLE
Lowercase HTML in Doctype

### DIFF
--- a/1-js/02-first-steps/01-hello-world/article.md
+++ b/1-js/02-first-steps/01-hello-world/article.md
@@ -16,7 +16,7 @@ JavaScript programs can be inserted in any place of HTML with the help of the `<
 For instance:
 
 ```html run height=100
-<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html>
 
 <body>


### PR DESCRIPTION
Because XHTML requires a lower-case html element, Polyglot documents should use lower-case html for the element named in the DOCTYPE declaration.